### PR TITLE
Fix interactive check

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,6 +21,6 @@ put into your own =.emacs= file (=init.el=)
 [[https://github.com/rolandwalker/hardhat][hardhat]] is a package similar to =auto-read-only.el=.
 It has large default settings, more flexible and has compatibility with a wide range of Emacs versions.
 
-=auto-read-only= works with a simple mechanism based on hook.
+=auto-read-only= works with a simple mechanism based on emacs’s built-in =window-buffer-change-functions=.
 It provides a minor mode, but it is not important.
 It also does not interfere with the behavior of non-interactive Emacs Lisp codes (ex. =package-install=).

--- a/README.org
+++ b/README.org
@@ -21,6 +21,6 @@ put into your own =.emacs= file (=init.el=)
 [[https://github.com/rolandwalker/hardhat][hardhat]] is a package similar to =auto-read-only.el=.
 It has large default settings, more flexible and has compatibility with a wide range of Emacs versions.
 
-=auto-read-only= works with a simple mechanism based on emacs’s built-in =window-buffer-change-functions=.
+=auto-read-only= works with a simple mechanism based on emacs’s built-in hook =window-buffer-change-functions=.
 It provides a minor mode, but it is not important.
 It also does not interfere with the behavior of non-interactive Emacs Lisp codes (ex. =package-install=).

--- a/auto-read-only.el
+++ b/auto-read-only.el
@@ -71,11 +71,11 @@
 
 (defvar auto-read-only-mode-lighter " AutoRO")
 
-(defun auto-read-only (window-or-frame)
-  "Enable `view-mode' in the buffer displayed in WINDOW-OR-FRAME, if
+(defun auto-read-only--maybe-activate (window-or-frame)
+  "Activate `auto-read-only' in the buffer displayed in WINDOW-OR-FRAME, if
 appropriate.
 
-Specifically, enable `view-mode' if the buffer in question:
+Specifically, activate `auto-read-only' if the buffer in question:
 
  1) is visiting a file which matches one of the regexps in
  `auto-read-only-file-regexps', and
@@ -96,13 +96,7 @@ When `auto-read-only-mode' is enabled, this function is added to
                  ((framep window-or-frame)
                   (window-buffer (frame-selected-window window-or-frame))))))
     (with-current-buffer buffer
-      (when (and buffer-file-name
-                 (cl-loop for regexp in auto-read-only-file-regexps
-                          thereis (string-match-p regexp buffer-file-name))
-                 (not (cdr (project-current))))
-        (if auto-read-only-function
-            (funcall auto-read-only-function)
-          (view-mode 1))))))
+      (auto-read-only))))
 
 ;;;###autoload
 (define-minor-mode auto-read-only-mode
@@ -110,8 +104,19 @@ When `auto-read-only-mode' is enabled, this function is added to
   nil auto-read-only-mode-lighter nil
   :global t
   (if auto-read-only-mode
-      (push #'auto-read-only window-buffer-change-functions)
-    (setq window-buffer-change-functions (delq #'auto-read-only window-buffer-change-functions))))
+      (push #'auto-read-only--maybe-activate window-buffer-change-functions)
+    (setq window-buffer-change-functions (delq #'auto-read-only--maybe-activate window-buffer-change-functions))))
+
+;;;###autoload
+(defun auto-read-only ()
+"Apply read-only mode to the current buffer."
+(when (and buffer-file-name
+           (cl-loop for regexp in auto-read-only-file-regexps
+                    thereis (string-match-p regexp buffer-file-name))
+           (not (cdr (project-current))))
+  (if auto-read-only-function
+      (funcall auto-read-only-function)
+    (view-mode 1))))
 
 (provide 'auto-read-only)
 ;;; auto-read-only.el ends here

--- a/auto-read-only.el
+++ b/auto-read-only.el
@@ -7,7 +7,7 @@
 ;; Version: 0.0.1
 ;; Keywords: files, convenience
 ;; Homepage: https://github.com/zonuexe/auto-read-only.el
-;; Package-Requires: ((emacs "25.1") (cl-lib "0.5"))
+;; Package-Requires: ((emacs "27.1") (cl-lib "0.5"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -71,11 +71,38 @@
 
 (defvar auto-read-only-mode-lighter " AutoRO")
 
-(defun auto-read-only--hook-find-file ()
-  "To apply read-only if detect called `find-file' interactivly."
-  (when (and (eq (window-buffer) (current-buffer))  ;; it means "file was opened interactivly".
-             (not (cdr (project-current))))
-    (auto-read-only)))
+(defun auto-read-only (window-or-frame)
+  "Enable `view-mode' in the buffer displayed in WINDOW-OR-FRAME, if
+appropriate.
+
+Specifically, enable `view-mode' if the buffer in question:
+
+ 1) is visiting a file which matches one of the regexps in
+ `auto-read-only-file-regexps', and
+
+ 2) that file is not part of a project.
+
+The fact that the buffer is being viewed by WINDOW-OR-FRAME means that
+it has not been visited programmatically, and so lisp code that visits
+files non-interactively should be unaffected.
+
+When `auto-read-only-mode' is enabled, this function is added to
+`window-buffer-change-functions' (which see)."
+
+  (let ((buffer (cond
+                 ((windowp window-or-frame)
+                  (window-buffer window-or-frame))
+
+                 ((framep window-or-frame)
+                  (window-buffer (frame-selected-window window-or-frame))))))
+    (with-current-buffer buffer
+      (when (and buffer-file-name
+                 (cl-loop for regexp in auto-read-only-file-regexps
+                          thereis (string-match-p regexp buffer-file-name))
+                 (not (cdr (project-current))))
+        (if auto-read-only-function
+            (funcall auto-read-only-function)
+          (view-mode 1))))))
 
 ;;;###autoload
 (define-minor-mode auto-read-only-mode
@@ -83,18 +110,8 @@
   nil auto-read-only-mode-lighter nil
   :global t
   (if auto-read-only-mode
-      (add-hook 'find-file-hook #'auto-read-only--hook-find-file)
-    (remove-hook 'find-file-hook #'auto-read-only--hook-find-file)))
-
-;;;###autoload
-(defun auto-read-only ()
-  "Apply read-only mode."
-  (when (and buffer-file-name
-             (cl-loop for regexp in auto-read-only-file-regexps
-                      thereis (string-match-p regexp buffer-file-name)))
-    (if auto-read-only-function
-      (funcall auto-read-only-function)
-    (view-mode 1))))
+      (push #'auto-read-only window-buffer-change-functions)
+    (setq window-buffer-change-functions (delq #'auto-read-only window-buffer-change-functions))))
 
 (provide 'auto-read-only)
 ;;; auto-read-only.el ends here

--- a/auto-read-only.el
+++ b/auto-read-only.el
@@ -104,8 +104,8 @@ When `auto-read-only-mode' is enabled, this function is added to
   nil auto-read-only-mode-lighter nil
   :global t
   (if auto-read-only-mode
-      (push #'auto-read-only--maybe-activate window-buffer-change-functions)
-    (setq window-buffer-change-functions (delq #'auto-read-only--maybe-activate window-buffer-change-functions))))
+      (add-hook 'window-buffer-change-functions #'auto-read-only--maybe-activate )
+    (remove-hook 'window-buffer-change-functions #'auto-read-only--maybe-activate)))
 
 ;;;###autoload
 (defun auto-read-only ()

--- a/auto-read-only.el
+++ b/auto-read-only.el
@@ -109,14 +109,14 @@ When `auto-read-only-mode' is enabled, this function is added to
 
 ;;;###autoload
 (defun auto-read-only ()
-"Apply read-only mode to the current buffer."
-(when (and buffer-file-name
-           (cl-loop for regexp in auto-read-only-file-regexps
-                    thereis (string-match-p regexp buffer-file-name))
-           (not (cdr (project-current))))
-  (if auto-read-only-function
-      (funcall auto-read-only-function)
-    (view-mode 1))))
+  "Apply read-only mode to the current buffer."
+  (when (and buffer-file-name
+             (cl-loop for regexp in auto-read-only-file-regexps
+                      thereis (string-match-p regexp buffer-file-name))
+             (not (cdr (project-current))))
+    (if auto-read-only-function
+        (funcall auto-read-only-function)
+      (view-mode 1))))
 
 (provide 'auto-read-only)
 ;;; auto-read-only.el ends here

--- a/auto-read-only.el
+++ b/auto-read-only.el
@@ -75,13 +75,6 @@
   "Activate `auto-read-only' in the buffer displayed in WINDOW-OR-FRAME, if
 appropriate.
 
-Specifically, activate `auto-read-only' if the buffer in question:
-
- 1) is visiting a file which matches one of the regexps in
- `auto-read-only-file-regexps', and
-
- 2) that file is not part of a project.
-
 The fact that the buffer is being viewed by WINDOW-OR-FRAME means that
 it has not been visited programmatically, and so lisp code that visits
 files non-interactively should be unaffected.
@@ -109,7 +102,15 @@ When `auto-read-only-mode' is enabled, this function is added to
 
 ;;;###autoload
 (defun auto-read-only ()
-  "Apply read-only mode to the current buffer."
+  "Apply read-only mode to the current buffer.
+
+Specifically, activate read-only mode if the current buffer:
+
+ 1) is visiting a file which matches one of the regexps in
+ `auto-read-only-file-regexps', and
+
+ 2) that file is not part of a project."
+
   (when (and buffer-file-name
              (cl-loop for regexp in auto-read-only-file-regexps
                       thereis (string-match-p regexp buffer-file-name))


### PR DESCRIPTION
Hello, this PR aims to fix issue #5 by reworking the mechanism for detecting whether the buffer is interactive or not. 

The new mechanism relies on `window-buffer-change-functions`, which was added in emacs 27.1. This is a hook whose functions are called whenever a window changes the buffer it is viewing, or whenever a frame has its window configuration changed. In our case, only one function is added to the list, `auto-read-only--maybe-activate`, which accepts a window or a frame as a parameter and calls `auto-read-only` on the corresponding buffer.
